### PR TITLE
Update to new genres API introducing subgenres

### DIFF
--- a/src/GrooveApiClient/GrooveClient.cs
+++ b/src/GrooveApiClient/GrooveClient.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Groove.Api.Client
             string country = null,
             string language = null)
         {
-            return BrowseAsync(mediaNamespace, "genres", country, language);
+            return BrowseAsync(mediaNamespace, "genres", country, language, 3);
         }
 
         public Task<ContentResponse> BrowseMoodsAsync(MediaNamespace mediaNamespace, string country, string language)
@@ -397,14 +397,14 @@ namespace Microsoft.Groove.Api.Client
             return BrowseAsync(mediaNamespace, "activities", country, language);
         }
 
-        private async Task<ContentResponse> BrowseAsync(MediaNamespace mediaNamespace, string browseCategory, string country, string language)
+        private async Task<ContentResponse> BrowseAsync(MediaNamespace mediaNamespace, string browseCategory, string country, string language, int apiVersion = 1)
         {
             Dictionary<string, string> requestHeaders = await FormatRequestHeadersAsync(null);
             Dictionary<string, string> requestParameters = await FormatRequestParametersAsync(language: language, country: country);
 
             return await GetAsync<ContentResponse>(
                 Hostname,
-                $"/1/content/{mediaNamespace}/catalog/{browseCategory}",
+                $"/{apiVersion}/content/{mediaNamespace}/catalog/{browseCategory}",
                 new CancellationToken(false),
                 requestParameters,
                 requestHeaders);

--- a/src/GrooveApiClient/IGrooveClient.cs
+++ b/src/GrooveApiClient/IGrooveClient.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Groove.Api.Client
         /// <param name="mediaNamespace">"music" only for now</param>
         /// <param name="country">ISO 2 letter code</param>
         /// <param name="language">ISO 2 letter code</param>
-        /// <returns>Response.Genres contains the list of genres for your locale</returns>
+        /// <returns>Response.CatalogGenres contains the list of genres for your locale</returns>
         Task<ContentResponse> BrowseGenresAsync(
             MediaNamespace mediaNamespace,
             string country = null,

--- a/src/GrooveApiDataContract/DataContract/ContentResponse.cs
+++ b/src/GrooveApiDataContract/DataContract/ContentResponse.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Groove.Api.DataContract
         public PaginatedList<ContentItem> Results { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public GenreList Genres { get; set; }
+        public List<Genre> CatalogGenres { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
         public List<Mood> CatalogMoods { get; set; }

--- a/src/GrooveApiDataContract/DataContract/GenericCollections.cs
+++ b/src/GrooveApiDataContract/DataContract/GenericCollections.cs
@@ -17,22 +17,22 @@ namespace Microsoft.Groove.Api.DataContract
     public class GenreList : List<string>
     {
         public GenreList()
-        {}
+        { }
 
         public GenreList(IEnumerable<string> collection)
             : base(collection)
-        {}
+        { }
     }
 
     [CollectionDataContract(Namespace = Constants.Xmlns, ItemName = "Right")]
     public class RightList : List<string>
     {
         public RightList()
-        {}
+        { }
 
         public RightList(IEnumerable<string> collection)
             : base(collection)
-        {}
+        { }
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2237:Mark ISerializable types with SerializableAttribute", Justification = "SerializableAttribute does not exist in Portable .NET")]
@@ -40,21 +40,21 @@ namespace Microsoft.Groove.Api.DataContract
     public class IdDictionary : Dictionary<string, string>
     {
         public IdDictionary()
-        {}
+        { }
 
         public IdDictionary(IDictionary<string, string> dictionary)
             : base(dictionary)
-        {}
+        { }
     }
 
     [CollectionDataContract(Namespace = Constants.Xmlns, ItemName = "TrackId")]
     public class TrackIdList : List<string>
     {
         public TrackIdList()
-        {}
+        { }
 
         public TrackIdList(IEnumerable<string> collection)
             : base(collection)
-        {}
+        { }
     }
 }

--- a/src/GrooveApiDataContract/DataContract/Genre.cs
+++ b/src/GrooveApiDataContract/DataContract/Genre.cs
@@ -1,0 +1,21 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  
+//  All Rights Reserved.
+//  Licensed under the MIT License.
+//  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Groove.Api.DataContract
+{
+    using System.Runtime.Serialization;
+
+    [DataContract(Namespace = Constants.Xmlns)]
+    public class Genre : ContentCategory
+    {
+        [DataMember(EmitDefaultValue = false)]
+        public string ParentName { get; set; }
+
+        [DataMember(EmitDefaultValue = true)]
+        public bool HasEditorialPlaylists { get; set; }
+    }
+}

--- a/src/GrooveApiDataContract/GrooveApiDataContract.csproj
+++ b/src/GrooveApiDataContract/GrooveApiDataContract.csproj
@@ -70,6 +70,7 @@
     <Compile Include="DataContract\GenericCollections.cs" />
     <Compile Include="DataContract\ItemType.cs" />
     <Compile Include="DataContract\MediaNamespace.cs" />
+    <Compile Include="DataContract\Genre.cs" />
     <Compile Include="DataContract\Mood.cs" />
     <Compile Include="DataContract\OrderBy.cs" />
     <Compile Include="DataContract\PaginatedList.cs" />

--- a/tests/GrooveApiClient.Tests/CatalogShould.cs
+++ b/tests/GrooveApiClient.Tests/CatalogShould.cs
@@ -97,8 +97,8 @@ namespace Microsoft.Groove.Api.Client.Tests
             ContentResponse genreResults = await Client.BrowseGenresAsync(MediaNamespace.music).Log();
             Assert.IsNotNull(genreResults, "The browse response should not be null");
             Console.WriteLine($"Culture: {genreResults.Culture}");
-            Assert.IsNotNull(genreResults.Genres, "The browse response should contain genres");
-            Assert.IsTrue(0 < genreResults.Genres.Count, "The browse response should contain at least one genre");
+            Assert.IsNotNull(genreResults.CatalogGenres, "The browse response should contain genres");
+            Assert.IsTrue(0 < genreResults.CatalogGenres.Count, "The browse response should contain at least one genre");
             Assert.IsNotNull(genreResults.Culture, "The genre response should contain the applicable culture");
         }
 

--- a/tests/GrooveApiClient.Tests/TestBaseExtensions.cs
+++ b/tests/GrooveApiClient.Tests/TestBaseExtensions.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Groove.Api.Client.Tests
         }
 
         private static async Task<TResponse> LogResponse<TResponse>(
-            this Task<TResponse> responseTask, 
-            Action<TResponse> log) 
+            this Task<TResponse> responseTask,
+            Action<TResponse> log)
             where TResponse : BaseResponse
         {
             TResponse response = await responseTask;
@@ -79,7 +79,7 @@ namespace Microsoft.Groove.Api.Client.Tests
                     {
                         Console.WriteLine($"  {content.GetType().Name} {content.Id}: {content.Name}, " +
                                           $"{string.Join(" and ", album.Artists.Select(contributor => contributor.Artist.Name))}");
-                    } 
+                    }
                     else if (track != null)
                     {
                         Console.WriteLine($"  {content.GetType().Name} {content.Id}: {content.Name}, {track.Album.Name}, " +
@@ -109,11 +109,11 @@ namespace Microsoft.Groove.Api.Client.Tests
                     }
                 }
 
-                if (response.Genres != null)
+                if (response.CatalogGenres != null)
                 {
-                    foreach (string genre in response.Genres)
+                    foreach (Genre genre in response.CatalogGenres)
                     {
-                        Console.WriteLine($" Genre: {genre}");
+                        Console.WriteLine($" Genre: {genre.Name}");
                     }
                 }
             });


### PR DESCRIPTION
This change contain a breaking change: in ContentResponse, Genres is renamed to CatalogGenres and is now a List of Genres